### PR TITLE
Include requirements.txt in source build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/hjweide/pyastar2d.svg?branch=master)](https://travis-ci.org/hjweide/pyastar2d)
+[![Build Status](https://travis-ci.com/hjweide/pyastar2d.svg?branch=master)](https://travis-ci.com/hjweide/pyastar2d)
 [![Coverage Status](https://coveralls.io/repos/github/hjweide/pyastar2d/badge.svg?branch=master)](https://coveralls.io/github/hjweide/pyastar2d?branch=master)
 [![PyPI version](https://badge.fury.io/py/pyastar2d.svg)](https://badge.fury.io/py/pyastar2d)
 # PyAstar2D

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pyastar2d",
-    version="1.0.1",
+    version="1.0.2",
     author="Hendrik Weideman",
     author_email="hjweide@gmail.com",
     description=(


### PR DESCRIPTION
Installing from pypi was failing because `requirements.txt` was missing.