### PR TITLE
prevent locally wandering paths by making diagonals cost 1.4x more

### DIFF
--- a/src/cpp/astar.cpp
+++ b/src/cpp/astar.cpp
@@ -97,11 +97,31 @@ static PyObject *astar(PyObject *self, PyObject *args) {
     nbrs[6] = (row + 1 < h)                            ? cur.idx + w       : -1;
     nbrs[7] = (diag_ok && row + 1 < h && col + 1 < w ) ? cur.idx + w + 1   : -1;
 
+    
+    // adding increased costs for diagonals
+    // for positions of: 
+    // 0 1 2
+    // 3   4
+    // 5 6 7 
+    // and heuristic costs of: (approximating sqrt(2) to 2 sig figs)
+    // 14 10 14
+    // 10    10
+    // 14 10 14
+    int* dir_costs = new int[8];
+    dir_costs[0] = 14;
+    dir_costs[1] = 10;
+    dir_costs[2] = 14;
+    dir_costs[3] = 10;
+    dir_costs[4] = 10;
+    dir_costs[5] = 14;
+    dir_costs[6] = 10;
+    dir_costs[7] = 14;
+
     float heuristic_cost;
     for (int i = 0; i < 8; ++i) {
       if (nbrs[i] >= 0) {
         // the sum of the cost so far and the cost of this move
-        float new_cost = costs[cur.idx] + weights[nbrs[i]];
+        float new_cost = costs[cur.idx] + weights[nbrs[i]] + dir_costs[i];
         if (new_cost < costs[nbrs[i]]) {
           // estimate the cost to the goal based on legal moves
           if (diag_ok) {


### PR DESCRIPTION
Hi all,

I noticed that diagonals do not have a heuristic cost that is greater than the taxicab distance, so I've added it in. 

Previously, this resulted in paths that seemed to wander around the shortest path somewhat, but now it looks good.

The technique I used is to approximate the diagonal distance of a unit square as the relative heuristic. 
However to keep the math using integers, I chose a square of side length 10 as the base cost, meaning that the diagonal would have cost 14.14..., which I've approximated as 14. This seemed to work well so I haven't tried to see if there's any more optimization that can be done here.