### PR TITLE
Upload wheels with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,75 @@
+os: linux
+dist: focal
 language: python
 python:
-  - "3.7"
+  - 3.8
+
+# cibuildwheel example: https://github.com/pypa/cibuildwheel/blob/main/examples/travis-ci-test-and-deploy.yml
 before_install:
-  - pip install -U pip
+  - |
+    if [[ "$TRAVIS_OS_NAME" = windows ]]; then
+        choco upgrade python -y --version 3.8.6
+        export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
+        # make sure it's on PATH as 'python3'
+        ln -s /c/Python38/python.exe /c/Python38/python3.exe
+    fi
+
 # command to install dependencies
 install:
-  - pip install -r requirements-dev.txt
-  - pip install coveralls  # python-coveralls leads to this issue: https://github.com/z4r/python-coveralls/issues/73
-  - pip install .
+  - python3 -m pip install -U pip
+  - python3 -m pip install -r requirements-dev.txt
+  - python3 -m pip install coveralls  # python-coveralls leads to this issue: https://github.com/z4r/python-coveralls/issues/73
+  - python3 -m pip install .
+
 # command to run tests
 script:
   - pytest --cov pyastar2d --cov-report term-missing
+
 after_success:
   - coveralls
+
+stages:
+  - test
+  # Only execute deployment stage on tagged commits, and from your repository
+  # (e.g. not PRs). Replace with your repo name.
+  - name: deploy
+    if: tag IS PRESENT AND repo = hjweide/pyastar2d
+    # To only build tags that look like vX.Y.Z:
+    #   if: tag =~ ^v\d+\.\d+\.\d+$ AND repo = pypa/cibuildwheel
+
+jobs:
+  include:
+    # Optional: run a test on Windows
+    - os: windows
+      language: shell
+      name: Test on Windows
+
+    # Deploy source distribution
+    - stage: deploy
+      name: Deploy source distribution
+      install: python3 -m pip install -r requirements.txt build twine
+      script: python3 -m build --sdist --config-setting=--formats=gztar
+      after_success: python3 -m twine upload --skip-existing dist/*.tar.gz
+    # Deploy on linux
+    - stage: deploy
+      name: Build and deploy Linux wheels
+      services: docker
+      install: python3 -m pip install -r requirements.txt cibuildwheel==2.4.0 twine
+      script: python3 -m cibuildwheel --output-dir wheelhouse
+      after_success: python3 -m twine upload --skip-existing wheelhouse/*.whl
+    # Deploy on windows
+    - stage: deploy
+      name: Build and deploy Windows wheels
+      os: windows
+      language: shell
+      install: python3 -m pip install -r requirements.txt cibuildwheel==2.4.0 twine
+      script: python3 -m cibuildwheel --output-dir wheelhouse
+      after_success: python3 -m twine upload --skip-existing wheelhouse/*.whl
+
+env:
+  global:
+    - TWINE_USERNAME=__token__
+    # Note: TWINE_PASSWORD is set to a PyPI API token in Travis settings
+
 notifications:
   email: false

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,12 @@
 import setuptools
 from distutils.core import Extension
-
-from setuptools.command.build_ext import build_ext as _build_ext
-
-
-# https://stackoverflow.com/a/21621689/
-class build_ext(_build_ext):
-    def finalize_options(self):
-        _build_ext.finalize_options(self)
-        # Prevent numpy from thinking it is still in its setup process:
-        __builtins__.__NUMPY_SETUP__ = False
-        import numpy
-        self.include_dirs.append(numpy.get_include())
-
+from setuptools import dist
+dist.Distribution().fetch_build_eggs(["numpy"])
+import numpy
 
 astar_module = Extension(
     'pyastar2d.astar', sources=['src/cpp/astar.cpp'],
+    include_dirs=[numpy.get_include()],  # for numpy/arrayobject.h
     extra_compile_args=["-O3", "-Wall", "-shared", "-fpic"],
 )
 
@@ -37,8 +28,6 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/hjweide/pyastar2d",
-    cmdclass={"build_ext": build_ext},
-    setup_requires=["wheel", "numpy"],
     install_requires=install_requires,
     packages=setuptools.find_packages(where="src", exclude=("tests",)),
     package_dir={"": "src"},
@@ -48,5 +37,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.8',
 )


### PR DESCRIPTION
I tried to update `.travis.yml` to build and upload the wheels automatically but couldn't get it to work. Maybe someone else knows how to do this?

This is the error I get building for both Linux and Windows:
```
   + rm -rf /tmp/cibuildwheel/built_wheel
    + mkdir -p /tmp/cibuildwheel/built_wheel
    + python -m pip wheel /project --wheel-dir=/tmp/cibuildwheel/built_wheel --no-deps
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [44 lines of output]
      /opt/python/pp38-pypy38_pp73/lib/pypy3.8/site-packages/setuptools/installer.py:30: SetuptoolsDeprecationWarning: setuptools.installer is deprecated. Requirements should be satisfied by a PEP 517 installer.
        SetuptoolsDeprecationWarning,
      Traceback (most recent call last):
        File "/project/.eggs/numpy-1.22.3-py3.8-linux-x86_64.egg/numpy/core/__init__.py", line 23, in <module>
          from . import multiarray
        File "/project/.eggs/numpy-1.22.3-py3.8-linux-x86_64.egg/numpy/core/multiarray.py", line 10, in <module>
          from . import overrides
        File "/project/.eggs/numpy-1.22.3-py3.8-linux-x86_64.egg/numpy/core/overrides.py", line 6, in <module>
          from numpy.core._multiarray_umath import (
      ModuleNotFoundError: No module named 'numpy.core._multiarray_umath'
      
      During handling of the above exception, another exception occurred:
      
      Traceback (most recent call last):
        File "<string>", line 36, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/project/setup.py", line 5, in <module>
          import numpy
        File "/project/.eggs/numpy-1.22.3-py3.8-linux-x86_64.egg/numpy/__init__.py", line 144, in <module>
          from . import core
        File "/project/.eggs/numpy-1.22.3-py3.8-linux-x86_64.egg/numpy/core/__init__.py", line 49, in <module>
          raise ImportError(msg)
      ImportError:
      
      IMPORTANT: PLEASE READ THIS FOR ADVICE ON HOW TO SOLVE THIS ISSUE!
      
      Importing the numpy C-extensions failed. This error can happen for
      many reasons, often due to issues with your setup or how NumPy was
      installed.
      
      We have compiled some common reasons and troubleshooting tips at:
      
          https://numpy.org/devdocs/user/troubleshooting-importerror.html
      
      Please note and check the following:
      
        * The Python version is: Python3.8 from "/opt/python/pp38-pypy38_pp73/bin/python"
        * The NumPy version is: "1.22.3"
      
      and make sure that they are the versions you expect.
      Please carefully study the documentation linked above for further help.
      
      Original error was: No module named 'numpy.core._multiarray_umath'
```