### PR TITLE
Feature/GitHub actions pypi packages

### DIFF
--- a/.github/workflows/python-publish-linux.yml
+++ b/.github/workflows/python-publish-linux.yml
@@ -43,6 +43,8 @@ jobs:
     - name: Publish distribution 📦 to Test PyPI
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        #TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
-          python -m twine upload --repository testpypi dist/*-manylinux*.whl --verbose --skip-existing
+          #python -m twine upload --repository testpypi dist/*-manylinux*.whl --verbose --skip-existing
+          python -m twine upload dist/*-manylinux*.whl --verbose --skip-existing

--- a/.github/workflows/python-publish-linux.yml
+++ b/.github/workflows/python-publish-linux.yml
@@ -6,7 +6,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Upload Python Package
+name: Upload Python Package Linux
 
 on:
   release:

--- a/.github/workflows/python-publish-linux.yml
+++ b/.github/workflows/python-publish-linux.yml
@@ -1,0 +1,48 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.7'
+    - name: Run tests
+      run: |
+        pip install .
+        pip install -r requirements-dev.txt
+        py.test
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install twine
+    - name: Build manylinux Python wheels
+      uses: RalfG/python-wheels-manylinux-build@v0.4.2-manylinux2014_x86_64
+      with:
+        python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310'
+        build-requirements: 'numpy'
+    - name: Publish distribution 📦 to Test PyPI
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      run: |
+          python -m twine upload --repository testpypi dist/*-manylinux*.whl --verbose --skip-existing

--- a/.github/workflows/python-publish-macos.yml
+++ b/.github/workflows/python-publish-macos.yml
@@ -6,7 +6,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Upload Python Package
+name: Upload Python Package MacOs
 
 on:
   release:

--- a/.github/workflows/python-publish-macos.yml
+++ b/.github/workflows/python-publish-macos.yml
@@ -45,7 +45,9 @@ jobs:
     - name: Publish distribution 📦 to Test PyPI
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        #TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
-          python -m twine upload --repository testpypi dist/* --verbose --skip-existing
+          #python -m twine upload --repository testpypi dist/* --verbose --skip-existing
+          python -m twine upload dist/* --verbose --skip-existing
 

--- a/.github/workflows/python-publish-macos.yml
+++ b/.github/workflows/python-publish-macos.yml
@@ -1,0 +1,51 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: macos-11
+    
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: "${{ matrix.python-version }}"
+    - name: Run tests
+      run: |
+        pip install .
+        pip install -r requirements-dev.txt
+        py.test
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install twine
+    - name: "Build package for python ${{ matrix.python-version }}"
+      run: |
+        python setup.py bdist_wheel
+    - name: Publish distribution 📦 to Test PyPI
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      run: |
+          python -m twine upload --repository testpypi dist/* --verbose --skip-existing
+

--- a/.github/workflows/python-publish-windows.yml
+++ b/.github/workflows/python-publish-windows.yml
@@ -6,7 +6,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Upload Python Package
+name: Upload Python Package Windows
 
 on:
   release:

--- a/.github/workflows/python-publish-windows.yml
+++ b/.github/workflows/python-publish-windows.yml
@@ -1,0 +1,50 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: windows-2022
+    
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: "${{ matrix.python-version }}"
+    - name: Run tests
+      run: |
+        pip install .
+        pip install -r requirements-dev.txt
+        py.test
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install twine
+    - name: "Build package for python ${{ matrix.python-version }}"
+      run: |
+        python setup.py bdist_wheel
+    - name: Publish distribution 📦 to Test PyPI
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      run: |
+          python -m twine upload --repository testpypi dist/* --verbose --skip-existing

--- a/.github/workflows/python-publish-windows.yml
+++ b/.github/workflows/python-publish-windows.yml
@@ -45,6 +45,8 @@ jobs:
     - name: Publish distribution 📦 to Test PyPI
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        #TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
-          python -m twine upload --repository testpypi dist/* --verbose --skip-existing
+          #python -m twine upload --repository testpypi dist/* --verbose --skip-existing
+          python -m twine upload dist/* --verbose --skip-existing

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,75 +1,17 @@
-os: linux
-dist: focal
 language: python
 python:
-  - 3.8
-
-# cibuildwheel example: https://github.com/pypa/cibuildwheel/blob/main/examples/travis-ci-test-and-deploy.yml
+  - "3.7"
 before_install:
-  - |
-    if [[ "$TRAVIS_OS_NAME" = windows ]]; then
-        choco upgrade python -y --version 3.8.6
-        export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
-        # make sure it's on PATH as 'python3'
-        ln -s /c/Python38/python.exe /c/Python38/python3.exe
-    fi
-
+  - pip install -U pip
 # command to install dependencies
 install:
-  - python3 -m pip install -U pip
-  - python3 -m pip install -r requirements-dev.txt
-  - python3 -m pip install coveralls  # python-coveralls leads to this issue: https://github.com/z4r/python-coveralls/issues/73
-  - python3 -m pip install .
-
+  - pip install -r requirements-dev.txt
+  - pip install coveralls  # python-coveralls leads to this issue: https://github.com/z4r/python-coveralls/issues/73
+  - pip install .
 # command to run tests
 script:
   - pytest --cov pyastar2d --cov-report term-missing
-
 after_success:
   - coveralls
-
-stages:
-  - test
-  # Only execute deployment stage on tagged commits, and from your repository
-  # (e.g. not PRs). Replace with your repo name.
-  - name: deploy
-    if: tag IS PRESENT AND repo = hjweide/pyastar2d
-    # To only build tags that look like vX.Y.Z:
-    #   if: tag =~ ^v\d+\.\d+\.\d+$ AND repo = pypa/cibuildwheel
-
-jobs:
-  include:
-    # Optional: run a test on Windows
-    - os: windows
-      language: shell
-      name: Test on Windows
-
-    # Deploy source distribution
-    - stage: deploy
-      name: Deploy source distribution
-      install: python3 -m pip install -r requirements.txt build twine
-      script: python3 -m build --sdist --config-setting=--formats=gztar
-      after_success: python3 -m twine upload --skip-existing dist/*.tar.gz
-    # Deploy on linux
-    - stage: deploy
-      name: Build and deploy Linux wheels
-      services: docker
-      install: python3 -m pip install -r requirements.txt cibuildwheel==2.4.0 twine
-      script: python3 -m cibuildwheel --output-dir wheelhouse
-      after_success: python3 -m twine upload --skip-existing wheelhouse/*.whl
-    # Deploy on windows
-    - stage: deploy
-      name: Build and deploy Windows wheels
-      os: windows
-      language: shell
-      install: python3 -m pip install -r requirements.txt cibuildwheel==2.4.0 twine
-      script: python3 -m cibuildwheel --output-dir wheelhouse
-      after_success: python3 -m twine upload --skip-existing wheelhouse/*.whl
-
-env:
-  global:
-    - TWINE_USERNAME=__token__
-    # Note: TWINE_PASSWORD is set to a PyPI API token in Travis settings
-
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,75 @@
+os: linux
+dist: focal
 language: python
 python:
-  - "3.7"
+  - 3.8
+
+# cibuildwheel example: https://github.com/pypa/cibuildwheel/blob/main/examples/travis-ci-test-and-deploy.yml
 before_install:
-  - pip install -U pip
+  - |
+    if [[ "$TRAVIS_OS_NAME" = windows ]]; then
+        choco upgrade python -y --version 3.8.6
+        export PATH="/c/Python38:/c/Python38/Scripts:$PATH"
+        # make sure it's on PATH as 'python3'
+        ln -s /c/Python38/python.exe /c/Python38/python3.exe
+    fi
+
 # command to install dependencies
 install:
-  - pip install -r requirements-dev.txt
-  - pip install coveralls  # python-coveralls leads to this issue: https://github.com/z4r/python-coveralls/issues/73
-  - pip install .
+  - python3 -m pip install -U pip
+  - python3 -m pip install -r requirements-dev.txt
+  - python3 -m pip install coveralls  # python-coveralls leads to this issue: https://github.com/z4r/python-coveralls/issues/73
+  - python3 -m pip install .
+
 # command to run tests
 script:
   - pytest --cov pyastar2d --cov-report term-missing
+
 after_success:
   - coveralls
+
+stages:
+  - test
+  # Only execute deployment stage on tagged commits, and from your repository
+  # (e.g. not PRs). Replace with your repo name.
+  - name: deploy
+    if: tag IS PRESENT AND repo = hjweide/pyastar2d
+    # To only build tags that look like vX.Y.Z:
+    #   if: tag =~ ^v\d+\.\d+\.\d+$ AND repo = pypa/cibuildwheel
+
+jobs:
+  include:
+    # Optional: run a test on Windows
+    - os: windows
+      language: shell
+      name: Test on Windows
+
+    # Deploy source distribution
+    - stage: deploy
+      name: Deploy source distribution
+      install: python3 -m pip install -r requirements.txt build twine
+      script: python3 -m build --sdist --config-setting=--formats=gztar
+      after_success: python3 -m twine upload --skip-existing dist/*.tar.gz
+    # Deploy on linux
+    - stage: deploy
+      name: Build and deploy Linux wheels
+      services: docker
+      install: python3 -m pip install -r requirements.txt cibuildwheel==2.4.0 twine
+      script: python3 -m cibuildwheel --output-dir wheelhouse
+      after_success: python3 -m twine upload --skip-existing wheelhouse/*.whl
+    # Deploy on windows
+    - stage: deploy
+      name: Build and deploy Windows wheels
+      os: windows
+      language: shell
+      install: python3 -m pip install -r requirements.txt cibuildwheel==2.4.0 twine
+      script: python3 -m cibuildwheel --output-dir wheelhouse
+      after_success: python3 -m twine upload --skip-existing wheelhouse/*.whl
+
+env:
+  global:
+    - TWINE_USERNAME=__token__
+    # Note: TWINE_PASSWORD is set to a PyPI API token in Travis settings
+
 notifications:
   email: false

--- a/setup.py
+++ b/setup.py
@@ -37,5 +37,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.8',
+    python_requires='>=3.6',
 )

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,12 @@
 import setuptools
 from distutils.core import Extension
-
-from setuptools.command.build_ext import build_ext as _build_ext
-
-
-# https://stackoverflow.com/a/21621689/
-class build_ext(_build_ext):
-    def finalize_options(self):
-        _build_ext.finalize_options(self)
-        # Prevent numpy from thinking it is still in its setup process:
-        __builtins__.__NUMPY_SETUP__ = False
-        import numpy
-        self.include_dirs.append(numpy.get_include())
-
+from setuptools import dist
+dist.Distribution().fetch_build_eggs(["numpy"])
+import numpy
 
 astar_module = Extension(
     'pyastar2d.astar', sources=['src/cpp/astar.cpp'],
+    include_dirs=[numpy.get_include()],  # for numpy/arrayobject.h
     extra_compile_args=["-O3", "-Wall", "-shared", "-fpic"],
 )
 
@@ -37,8 +28,6 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/hjweide/pyastar2d",
-    cmdclass={"build_ext": build_ext},
-    setup_requires=["wheel", "numpy"],
     install_requires=install_requires,
     packages=setuptools.find_packages(where="src", exclude=("tests",)),
     package_dir={"": "src"},
@@ -48,5 +37,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.8',
 )


### PR DESCRIPTION
Github action files to push windows, mac and linux packages to pypi.

Please see below link for what uploaded file looks like on test.pypi:

https://test.pypi.org/project/pyastar2d-peterchenadded/1.0.2/#files

Please see below for logs of pipeline runs:

https://github.com/peterchenadded/pyastar2d/actions - note only v1.0.12 was success, rest was still testing

Some other notes:

1. To trigger off the pipeline just make a new release in master and make sure the setup.py version is updated
2. There are three files one for windows, mac and another for linux. This is to parallel the runs and also the build steps for linux is different as it needs to build manylinux .whl
3. It will run your py.test before building and packaging the .whl files
4. Many sure to setup a repo secret called PYPI_API_TOKEN which is your pypi api token
5. You can support other python versions by updating below in respective github workflow files:

mac/windows

```
strategy:
      matrix:
        python-version: ["3.7", "3.8", "3.9", "3.10"]
```

linux

```
python-versions: 'cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310'
```

6. You can publish to testpypi instead of pypi (production) by switching the below lines:

```
#python -m twine upload --repository testpypi dist/*-manylinux*.whl --verbose --skip-existing
python -m twine upload dist/*-manylinux*.whl --verbose --skip-existing
```
