### PR TITLE
Missing .h file in source distribution, causing pip install no-binary to fail.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include requirements.txt
+include src/cpp/experimental_heuristics.h


### PR DESCRIPTION
Was getting below error on mac M1 laptop which needed to compile the source distribution.

```
src/cpp/astar.cpp:7:10: error: 'experimental_heuristics.h' file not found with <angled> include; use "quotes" instead
      #include <experimental_heuristics.h>
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~
               "experimental_heuristics.h"
      1 warning and 1 error generated.
      error: command 'clang' failed with exit status 1
      [end of output]

```

You should be able to reproduce the issue everywhere with below commands:

```
pip uninstall pyastar2d
pip install pyastar2d --no-binary :all:
```

The new single MANIFEST.in entry, adds the .h to source dist and allows it to be referenced correctly when installing without binary.

Apologies not testing this scenario and only finding out the issue now.